### PR TITLE
Added support for tag options and field to ignore when Marshalling a struct

### DIFF
--- a/bencode_test.go
+++ b/bencode_test.go
@@ -237,16 +237,16 @@ func BenchmarkDecodeAll(b *testing.B) {
 }
 
 type structA struct {
-	A int    "a"
+	A int    `bencode:"a"`
 	B string `example:"data" bencode:"b"`
 	C string `example:"data2" bencode:"sea monster"`
 }
 
 type structNested struct {
-	T string            "t"
-	Y string            "y"
-	Q string            "q"
-	A map[string]string "a"
+	T string            `bencode:"t"`
+	Y string            `bencode:"y"`
+	Q string            `bencode:"q"`
+	A map[string]string `bencode:"a"`
 }
 
 var (
@@ -335,6 +335,19 @@ func TestMarshalWithOmitEmptyFieldEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 	buf2 := "d3:Agei42e9:FirstName4:Jack8:LastName6:Daniele"
+	if string(buf.Bytes()) != buf2 {
+		t.Fatalf("Wrong encoding, expected first line got second line\n`%s`\n`%s`\n", buf2, string(buf.Bytes()))
+	}
+}
+
+func TestMarshalWithOmitEmptyFieldNonEmpty(t *testing.T) {
+	oe := omitEmpty{42, []string{"first", "second"}, "Jack", "Not ignored", "Daniel", "Whisky"}
+	var buf bytes.Buffer
+	err := Marshal(&buf, oe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf2 := "d3:Agei42e5:Arrayl5:first6:seconde9:FirstName4:Jack7:Ignored11:Not ignored8:LastName6:Daniel9:otherName6:Whiskye"
 	if string(buf.Bytes()) != buf2 {
 		t.Fatalf("Wrong encoding, expected first line got second line\n`%s`\n`%s`\n", buf2, string(buf.Bytes()))
 	}

--- a/bencode_test.go
+++ b/bencode_test.go
@@ -237,16 +237,16 @@ func BenchmarkDecodeAll(b *testing.B) {
 }
 
 type structA struct {
-	A int    `bencode:"a"`
+	A int    "a"
 	B string `example:"data" bencode:"b"`
 	C string `example:"data2" bencode:"sea monster"`
 }
 
 type structNested struct {
-	T string            `bencode:"t"`
-	Y string            `bencode:"y"`
-	Q string            `bencode:"q"`
-	A map[string]string `bencode:"a"`
+	T string            "t"
+	Y string            "y"
+	Q string            "q"
+	A map[string]string "a"
 }
 
 var (

--- a/bencode_test.go
+++ b/bencode_test.go
@@ -284,3 +284,36 @@ func BenchmarkUnmarshalAll(b *testing.B) {
 		}
 	}
 }
+
+type identity struct {
+	Age       int
+	FirstName string
+	Ignored   string `bencode:"-"`
+	LastName  string
+}
+
+func TestMarshalWithIgnoredField(t *testing.T) {
+	id := identity{42, "Jack", "Why are you ignoring me?", "Daniel"}
+	var buf bytes.Buffer
+	err := Marshal(&buf, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var id2 identity
+	err = Unmarshal(&buf, &id2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id.Age != id2.Age {
+		t.Fatal("Age should be the same, expected %d, got %d", id.Age, id2.Age)
+	}
+	if id.FirstName != id2.FirstName {
+		t.Fatal("FirstName should be the same, expected %s, got %s", id.FirstName, id2.FirstName)
+	}
+	if id.LastName != id2.LastName {
+		t.Fatal("LastName should be the same, expected %s, got %s", id.LastName, id2.LastName)
+	}
+	if id2.Ignored != "" {
+		t.Fatal("Ignored should be empty, got %s", id2.Ignored)
+	}
+}

--- a/bencode_test.go
+++ b/bencode_test.go
@@ -317,3 +317,25 @@ func TestMarshalWithIgnoredField(t *testing.T) {
 		t.Fatal("Ignored should be empty, got %s", id2.Ignored)
 	}
 }
+
+type omitEmpty struct {
+	Age       int
+	Array     []string `bencode:",omitempty"`
+	FirstName string
+	Ignored   string `bencode:",omitempty"`
+	LastName  string
+	Renamed   string `bencode:"otherName,omitempty"`
+}
+
+func TestMarshalWithOmitEmptyFieldEmpty(t *testing.T) {
+	oe := omitEmpty{42, []string{}, "Jack", "", "Daniel", ""}
+	var buf bytes.Buffer
+	err := Marshal(&buf, oe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf2 := "d3:Agei42e9:FirstName4:Jack8:LastName6:Daniele"
+	if string(buf.Bytes()) != buf2 {
+		t.Fatalf("Wrong encoding, expected first line got second line\n`%s`\n`%s`\n", buf2, string(buf.Bytes()))
+	}
+}

--- a/struct.go
+++ b/struct.go
@@ -204,7 +204,7 @@ func (b *structBuilder) Key(k string) builder {
 		k = strings.ToLower(k)
 		for i := 0; i < t.NumField(); i++ {
 			field := t.Field(i)
-			key := bencodeKey(field)
+			key := bencodeKey(field, nil)
 			if strings.ToLower(key) == k ||
 				strings.ToLower(field.Name) == k {
 				return &structBuilder{val: v.Field(i)}
@@ -337,8 +337,9 @@ func writeArrayOrSlice(w io.Writer, val reflect.Value) (err error) {
 }
 
 type stringValue struct {
-	key   string
-	value reflect.Value
+	key       string
+	value     reflect.Value
+	omitEmpty bool
 }
 
 type stringValueArray []stringValue
@@ -355,7 +356,7 @@ func writeSVList(w io.Writer, svList stringValueArray) (err error) {
 	sort.Sort(svList)
 
 	for _, sv := range svList {
-		if isValueNil(sv.value) {
+		if sv.isValueNil() {
 			continue // Skip null values
 		}
 		s := sv.key
@@ -403,13 +404,14 @@ func writeMap(w io.Writer, val reflect.Value) (err error) {
 	return
 }
 
-func bencodeKey(field reflect.StructField) (key string) {
+func bencodeKey(field reflect.StructField, sv *stringValue) (key string) {
 	key = field.Name
 	tag := field.Tag
 	if len(tag) > 0 {
 		// Backwards compatability
 		// If there's a bencode key/value entry in the tag, use it.
-		key = tag.Get("bencode")
+		var tagOpt tagOptions
+		key, tagOpt = parseTag(tag.Get("bencode"))
 		if len(key) == 0 {
 			// If there is no ":" in the tag, assume it is an old-style tag.
 			stringTag := string(tag)
@@ -417,8 +419,49 @@ func bencodeKey(field reflect.StructField) (key string) {
 				key = stringTag
 			}
 		}
+		if sv != nil && tagOpt.Contains("omitempty") {
+			sv.omitEmpty = true
+		}
+	}
+	if sv != nil {
+		sv.key = key
 	}
 	return
+}
+
+// tagOptions is the string following a comma in a struct field's "bencode"
+// tag, or the empty string. It does not include the leading comma.
+type tagOptions string
+
+// parseTag splits a struct field's bencode tag into its name and
+// comma-separated options.
+func parseTag(tag string) (string, tagOptions) {
+	if idx := strings.Index(tag, ","); idx != -1 {
+		return tag[:idx], tagOptions(tag[idx+1:])
+	}
+	return tag, tagOptions("")
+}
+
+// Contains reports whether a comma-separated list of options
+// contains a particular substr flag. substr must be surrounded by a
+// string boundary or commas.
+func (o tagOptions) Contains(optionName string) bool {
+	if len(o) == 0 {
+		return false
+	}
+	s := string(o)
+	for s != "" {
+		var next string
+		i := strings.Index(s, ",")
+		if i >= 0 {
+			s, next = s[:i], s[i+1:]
+		}
+		if s == optionName {
+			return true
+		}
+		s = next
+	}
+	return false
 }
 
 func writeStruct(w io.Writer, val reflect.Value) (err error) {
@@ -434,7 +477,7 @@ func writeStruct(w io.Writer, val reflect.Value) (err error) {
 
 	for i := 0; i < numFields; i++ {
 		field := typ.Field(i)
-		svList[i].key = bencodeKey(field)
+		bencodeKey(field, &svList[i])
 		// The tag `bencode:"-"` should mean that this field must be ignored
 		// See https://golang.org/pkg/encoding/json/#Marshal or https://golang.org/pkg/encoding/xml/#Marshal
 		// We set a zero value so that it is ignored by the writeSVList() function
@@ -487,15 +530,31 @@ func writeValue(w io.Writer, val reflect.Value) (err error) {
 	return
 }
 
-func isValueNil(val reflect.Value) bool {
-	if !val.IsValid() {
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
+func (sv stringValue) isValueNil() bool {
+	if !sv.value.IsValid() || (sv.omitEmpty && isEmptyValue(sv.value)) {
 		return true
 	}
-	switch v := val; v.Kind() {
+	switch v := sv.value; v.Kind() {
 	case reflect.Interface:
-		return isValueNil(v.Elem())
-	default:
-		return false
+		return !v.Elem().IsValid()
 	}
 	return false
 }

--- a/struct.go
+++ b/struct.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-
 	"reflect"
 	"sort"
 	"strings"
@@ -436,7 +435,14 @@ func writeStruct(w io.Writer, val reflect.Value) (err error) {
 	for i := 0; i < numFields; i++ {
 		field := typ.Field(i)
 		svList[i].key = bencodeKey(field)
-		svList[i].value = val.Field(i)
+		// The tag `bencode:"-"` should mean that this field must be ignored
+		// See https://golang.org/pkg/encoding/json/#Marshal or https://golang.org/pkg/encoding/xml/#Marshal
+		// We set a zero value so that it is ignored by the writeSVList() function
+		if svList[i].key == "-" {
+			svList[i].value = reflect.Value{}
+		} else {
+			svList[i].value = val.Field(i)
+		}
 	}
 
 	err = writeSVList(w, svList)

--- a/struct.go
+++ b/struct.go
@@ -413,11 +413,8 @@ func bencodeKey(field reflect.StructField, sv *stringValue) (key string) {
 		var tagOpt tagOptions
 		key, tagOpt = parseTag(tag.Get("bencode"))
 		if len(key) == 0 {
-			// If there is no ":" in the tag, assume it is an old-style tag.
-			stringTag := string(tag)
-			if !strings.Contains(stringTag, ":") {
-				key = stringTag
-			}
+			// Breaks backwards compatibility to allow this syntax `bencode:,omitempty`
+			key = field.Name
 		}
 		if sv != nil && tagOpt.Contains("omitempty") {
 			sv.omitEmpty = true

--- a/struct.go
+++ b/struct.go
@@ -413,8 +413,13 @@ func bencodeKey(field reflect.StructField, sv *stringValue) (key string) {
 		var tagOpt tagOptions
 		key, tagOpt = parseTag(tag.Get("bencode"))
 		if len(key) == 0 {
-			// Breaks backwards compatibility to allow this syntax `bencode:,omitempty`
-			key = field.Name
+			key = tag.Get("bencode")
+			if len(key) == 0 && !strings.Contains(string(tag), ":") {
+				// If there is no ":" in the tag, assume it is an old-style tag.
+				key = string(tag)
+			} else {
+				key = field.Name
+			}
 		}
 		if sv != nil && tagOpt.Contains("omitempty") {
 			sv.omitEmpty = true


### PR DESCRIPTION
You can now use the following syntax in a tag struct : 
```go
type myStruct struct {
// Ignored during Marshalling
Field string `bencode:"-"` 
// Ignored during Marshalling if empty otherwise named  "name"
Field2 string `bencode:"name,omitempty`
// Ignored during Marshalling if empty otherwise named with default field.Name in this case "Field3"
Field3 string `bencode:",omitempty`
}
```
In this version, the old tag style is no longer supported.