### PR TITLE
Fixes

### DIFF
--- a/bencode_test.go
+++ b/bencode_test.go
@@ -359,3 +359,18 @@ func TestMarshalWithOmitEmptyFieldNonEmpty(t *testing.T) {
 		t.Fatalf("Wrong encoding, expected first line got second line\n`%s`\n`%s`\n", buf2, string(buf.Bytes()))
 	}
 }
+
+func TestMatshalDifferentTypes(t *testing.T) {
+
+	buf := new(bytes.Buffer)
+	Marshal(buf, []byte{'1', '2', '3'})
+	if buf.String() != "3:123" {
+		t.Fatalf("Incorrectly encoded byte array, got %s", buf.String())
+	}
+
+	buf = new(bytes.Buffer)
+	Marshal(buf, []int{1, 2, 3})
+	if buf.String() != "li1ei2ei3ee" {
+		t.Fatalf("Incorrectly encoded byte array, got %s", buf.String())
+	}
+}

--- a/bencode_test.go
+++ b/bencode_test.go
@@ -17,7 +17,7 @@ func checkMarshal(expected string, data any) (err error) {
 	}
 	s := b.String()
 	if expected != s {
-		err = errors.New(fmt.Sprintf("Expected %s got %s", expected, s))
+		err = fmt.Errorf("Expected %s got %s", expected, s)
 		return
 	}
 	return

--- a/bencode_test.go
+++ b/bencode_test.go
@@ -312,16 +312,16 @@ func TestMarshalWithIgnoredField(t *testing.T) {
 		t.Fatal(err)
 	}
 	if id.Age != id2.Age {
-		t.Fatal("Age should be the same, expected %d, got %d", id.Age, id2.Age)
+		t.Fatalf("Age should be the same, expected %d, got %d", id.Age, id2.Age)
 	}
 	if id.FirstName != id2.FirstName {
-		t.Fatal("FirstName should be the same, expected %s, got %s", id.FirstName, id2.FirstName)
+		t.Fatalf("FirstName should be the same, expected %s, got %s", id.FirstName, id2.FirstName)
 	}
 	if id.LastName != id2.LastName {
-		t.Fatal("LastName should be the same, expected %s, got %s", id.LastName, id2.LastName)
+		t.Fatalf("LastName should be the same, expected %s, got %s", id.LastName, id2.LastName)
 	}
 	if id2.Ignored != "" {
-		t.Fatal("Ignored should be empty, got %s", id2.Ignored)
+		t.Fatalf("Ignored should be empty, got %s", id2.Ignored)
 	}
 }
 

--- a/bencode_test.go
+++ b/bencode_test.go
@@ -62,8 +62,6 @@ func fuzzyEqualInt64(a int64, b reflect.Value) bool {
 	switch vb := b; vb.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return a == (vb.Int())
-	default:
-		return false
 	}
 	return false
 }
@@ -74,8 +72,6 @@ func fuzzyEqualArrayOrSlice(va reflect.Value, b reflect.Value) bool {
 		return fuzzyEqualArrayOrSlice2(va, vb)
 	case reflect.Slice:
 		return fuzzyEqualArrayOrSlice2(va, vb)
-	default:
-		return false
 	}
 	return false
 }
@@ -177,8 +173,6 @@ func fuzzyEqualValue(a, b reflect.Value) bool {
 		default:
 			return false
 		}
-	default:
-		return false
 	}
 	return false
 }

--- a/parse.go
+++ b/parse.go
@@ -69,7 +69,6 @@ func collectInt(r *bufio.Reader, delim byte) (buf []byte, err error) {
 		}
 		buf = append(buf, c)
 	}
-	return
 }
 
 func decodeInt64(r *bufio.Reader, delim byte) (data int64, err error) {

--- a/parse.go
+++ b/parse.go
@@ -190,7 +190,7 @@ func parseFromReader(r *bufio.Reader, build builder) (err error) {
 			n++
 		}
 	default:
-		err = errors.New(fmt.Sprintf("Unexpected character: '%v'", c))
+		err = fmt.Errorf("Unexpected character: '%v'", c)
 	}
 exit:
 	build.Flush()

--- a/struct.go
+++ b/struct.go
@@ -519,7 +519,14 @@ func writeValue(w io.Writer, val reflect.Value) (err error) {
 	case reflect.Array:
 		err = writeArrayOrSlice(w, v)
 	case reflect.Slice:
-		err = writeArrayOrSlice(w, v)
+		switch val.Type().String() {
+		case "[]uint8":
+			// special case as byte-string
+			s := string(v.Bytes())
+			_, err = fmt.Fprintf(w, "%d:%s", len(s), s)
+		default:
+			err = writeArrayOrSlice(w, v)
+		}
 	case reflect.Map:
 		err = writeMap(w, v)
 	case reflect.Struct:


### PR DESCRIPTION
Found by 'go vet'.

After these fixes are applied, some errors remains, not sure how to handle these:

```
$ go vet
bencode_test.go:231: struct field tag "a" not compatible with reflect.StructTag.Get: bad syntax for struct tag pair
bencode_test.go:237: struct field tag "t" not compatible with reflect.StructTag.Get: bad syntax for struct tag pair
bencode_test.go:238: struct field tag "y" not compatible with reflect.StructTag.Get: bad syntax for struct tag pair
bencode_test.go:239: struct field tag "q" not compatible with reflect.StructTag.Get: bad syntax for struct tag pair
bencode_test.go:240: struct field tag "a" not compatible with reflect.StructTag.Get: bad syntax for struct tag pair
exit status 1
```